### PR TITLE
fixed a bug where xml wouldn't pass Airbrake's validation

### DIFF
--- a/airbrake.go
+++ b/airbrake.go
@@ -13,7 +13,7 @@ import (
 	"text/template"
 )
 
-aivar (
+var (
 	ApiKey   = ""
 	Endpoint = "https://api.airbrake.io/notifier_api/v2/notices"
 	Verbose  = false
@@ -140,19 +140,19 @@ func Error(e error, request *http.Request) error {
 
 	params["Backtrace"] = stacktrace(3)
 
-	post(params)
+    post(params)
 
-	return nil
+    return nil
 }
 
 func Notify(e error) error {
-	once.Do(initChannel)
-	
-	if ApiKey == "" {
-		return apiKeyMissing
-	}
-	
-	params := map[string]interface{}{
+    once.Do(initChannel)
+    
+    if ApiKey == "" {
+        return apiKeyMissing
+    }
+    
+    params := map[string]interface{}{
                 "Class":     reflect.TypeOf(e).String(),
                 "Error":     e,
                 "ApiKey":    ApiKey,
@@ -163,36 +163,36 @@ func Notify(e error) error {
             params["Class"] = "Panic"
         }
         
-	pwd, err := os.Getwd()
+    pwd, err := os.Getwd()
         
-	if err == nil {
+    if err == nil {
             params["Pwd"] = pwd                                             
         }
-	
-	hostname, err := os.Hostname()
+    
+    hostname, err := os.Hostname()
 
-	if err == nil {
+    if err == nil {
             params["Hostname"] = hostname
-	}
+    }
 
         post(params)
         return nil  
-	
+    
 }
 
 func CapturePanic(r *http.Request) {
-	if rec := recover(); rec != nil {
+    if rec := recover(); rec != nil {
 
-		if err, ok := rec.(error); ok {
-			log.Printf("Recording err %s", err)
-			Error(err, r)
-		} else if err, ok := rec.(string); ok {
-			log.Printf("Recording string %s", err)
-			Error(errors.New(err), r)
-		}
+        if err, ok := rec.(error); ok {
+            log.Printf("Recording err %s", err)
+            Error(err, r)
+        } else if err, ok := rec.(string); ok {
+            log.Printf("Recording string %s", err)
+            Error(errors.New(err), r)
+        }
 
-		panic(rec)
-	}
+        panic(rec)
+    }
 }
 
 const source = `<?xml version="1.0" encoding="UTF-8"?>

--- a/airbrake_test.go
+++ b/airbrake_test.go
@@ -8,9 +8,11 @@ import (
 	"time"
 )
 
+const API_KEY = ""
+
 func TestError(t *testing.T) {
 	Verbose = true
-	ApiKey = ""
+	ApiKey = API_KEY
 	Endpoint = "https://api.airbrake.io/notifier_api/v2/notices"
 
 	err := Error(errors.New("Test Error"), nil)
@@ -24,7 +26,7 @@ func TestError(t *testing.T) {
 
 func TestRequest(t *testing.T) {
 	Verbose = true
-	ApiKey = ""
+	ApiKey = API_KEY
 	Endpoint = "https://api.airbrake.io/notifier_api/v2/notices"
 
 	request, _ := http.NewRequest("GET", "/some/path?a=1", bytes.NewBufferString(""))
@@ -40,10 +42,10 @@ func TestRequest(t *testing.T) {
 
 func TestNotify(t *testing.T) {
 	Verbose = true
-	ApiKey = ""
+	ApiKey = API_KEY
 	Endpoint = "https://api.airbrake.io/notifier_api/v2/notices"
 	
-	err := Notify(errors.New("Test Error")
+	err := Notify(errors.New("Test Error"))
 	
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Problem was that `<project-root>` came after `<environment-name>` when, according to their xml schema, `<project-root>` should come first.
