### PR TITLE
Populate backtrace value in request on Notify

### DIFF
--- a/airbrake.go
+++ b/airbrake.go
@@ -175,6 +175,8 @@ func Notify(e error) error {
             params["Hostname"] = hostname
     }
 
+	params["Backtrace"] = stacktrace(3)
+        
         post(params)
         return nil  
     


### PR DESCRIPTION
This PR sets the backtrace request param to `stacktrace(3)` in the `airbrake.Notify` method which is the same as what is as assigned in the `airbrake.Error` method.

When backtrace isn't populated we're seeing an error response: https://gist.github.com/snormore/27856c8956bccc5421ec

@tobi @camilo
