### PR TITLE
Fix HTTP POST error handling and correct typos

### DIFF
--- a/airbrake.go
+++ b/airbrake.go
@@ -88,15 +88,19 @@ func post(params map[string]interface{}) {
 	buffer := bytes.NewBufferString("")
 
 	if err := tmpl.Execute(buffer, params); err != nil {
-		log.Printf("Airbreak error: %s", err)
+		log.Printf("Airbrake error: %s", err)
 		return
 	}
 
 	if Verbose {
-		log.Printf("Airbreak payload for endpoint %s: %s", Endpoint, buffer)
+		log.Printf("Airbrake payload for endpoint %s: %s", Endpoint, buffer)
 	}
 
 	response, err := http.Post(Endpoint, "text/xml", buffer)
+	if err != nil {
+		log.Printf("Airbrake error: %s", err)
+		return
+	}
 
 	if Verbose {
 		body, _ := ioutil.ReadAll(response.Body)
@@ -104,13 +108,8 @@ func post(params map[string]interface{}) {
 	}
 	response.Body.Close()
 
-	if err != nil {
-		log.Printf("Airbreak error: %s", err)
-		return
-	}
-
 	if Verbose {
-		log.Printf("Airbreak post: %s status code: %d", params["Error"], response.StatusCode)
+		log.Printf("Airbrake post: %s status code: %d", params["Error"], response.StatusCode)
 	}
 
 }

--- a/handler.go
+++ b/handler.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 )
 
-// CapturePanicHandler "middleware". 
-// Wraps the http handler so that all panics will be dutifully reported to airbreak
-// 
-// Example: 
+// CapturePanicHandler "middleware".
+// Wraps the http handler so that all panics will be dutifully reported to airbrake
+//
+// Example:
 //   http.HandleFunc("/", airbrake.CapturePanicHandler(MyServerFunc))
 func CapturePanicHandler(app http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Currently, when the POST fails, `(response, err)` is set to `(nil, <some err>)`. We need to return on err before running `response.Body.Close()`, else it panic()s.
