### PR TITLE
Populate the Environement and Parameters tab in errbit reports

### DIFF
--- a/airbrake.go
+++ b/airbrake.go
@@ -20,7 +20,8 @@ var (
 	Verbose     = false
 
 	// PrettyParams allows including request query/form parameters on the Environment tab
-	// which is more readable than the raw text of the Parameters tab (in Errbit)
+	// which is more readable than the raw text of the Parameters tab (in Errbit).
+	// The param keys will be rendered as "?<param>" so they will sort together at the top of the tab.
 	PrettyParams = false
 
 	badResponse   = errors.New("Bad response")

--- a/airbrake_test.go
+++ b/airbrake_test.go
@@ -58,8 +58,9 @@ func TestNotify(t *testing.T) {
 // Make sure we match https://help.airbrake.io/kb/api-2/notifier-api-version-23
 func TestTemplateV2(t *testing.T) {
 	var p map[string]interface{}
-	request, _ := http.NewRequest("GET", "/query?t=xxx&q=SHOW+x+BY+y+FROM+z&timezone=", nil)
+	request, _ := http.NewRequest("GET", "/query?t=xxx&q=SHOW+x+BY+y+FROM+z&key=sesame&timezone=", nil)
 	request.Header.Set("Host", "Zulu")
+	request.Header.Set("Keep_Secret", "Sesame")
 	PrettyParams = true
 	defer func() { PrettyParams = false }()
 
@@ -104,19 +105,19 @@ func TestTemplateV2(t *testing.T) {
 	// Validate the <request> node.
 	chunk = regexp.MustCompile(`(?s)<request>.*</request>`).FindString(b.String())
 	if chunk != `<request>
-    <url>/query?t=xxx&amp;q=SHOW+x+BY+y+FROM+z&amp;timezone=</url>
-    <component/>
-    <action/>
+    <url>/query?t=xxx&amp;q=SHOW+x+BY+y+FROM+z&amp;key=sesame&amp;timezone=</url>
+    <component></component>
+    <action></action>
     <params>
       <var key="q">SHOW x BY y FROM z</var>
       <var key="t">xxx</var>
     </params>
     <cgi-data>
-      <var key="Host">Zulu</var>
-      <var key="METHOD">GET</var>
-      <var key="PROTOCOL">HTTP/1.1</var>
       <var key="?q">SHOW x BY y FROM z</var>
       <var key="?t">xxx</var>
+      <var key="Host">Zulu</var>
+      <var key="Method">GET</var>
+      <var key="Protocol">HTTP/1.1</var>
     </cgi-data>
   </request>` {
 		t.Fatal(chunk)

--- a/airbrake_test.go
+++ b/airbrake_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"net/http"
+	"regexp"
 	"testing"
 	"time"
 )
@@ -44,12 +45,72 @@ func TestNotify(t *testing.T) {
 	Verbose = true
 	ApiKey = API_KEY
 	Endpoint = "https://api.airbrake.io/notifier_api/v2/notices"
-	
+
 	err := Notify(errors.New("Test Error"))
-	
+
 	if err != nil {
 		t.Error(err)
 	}
 
 	time.Sleep(1e9)
+}
+
+// Make sure we match https://help.airbrake.io/kb/api-2/notifier-api-version-23
+func TestTemplateV2(t *testing.T) {
+	var p map[string]interface{}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				p = params(r.(error))
+			}
+		}()
+		panic(errors.New("Boom!"))
+	}()
+
+	if p == nil {
+		t.Fail()
+	}
+
+	if len(p["Backtrace"].([]Line)) < 3 {
+		t.Fail()
+	}
+
+	// It's messy to generically test rendered backtrace.
+	delete(p, "Backtrace")
+
+	// Add request
+	if r, err := http.NewRequest("GET", "/query?t=xxx&q=SHOW+x+BY+y+FROM+z", nil); err != nil {
+		t.Fatal(err)
+	} else {
+		// Make sure parameters are parsed, otherwise they won't be rendered.
+		r.ParseForm()
+		p["Request"] = r
+	}
+
+	var b bytes.Buffer
+	if err := tmpl.Execute(&b, p); err != nil {
+		t.Fatalf("Template error: %s", err)
+	}
+
+	chunk := regexp.MustCompile(`(?s)<error>.*<backtrace>`).FindString(b.String())
+	if chunk != `<error>
+    <class>*errors.errorString</class>
+    <message>Boom!</message>
+    <backtrace>` {
+		t.Fatal(chunk)
+	}
+
+	chunk = regexp.MustCompile(`(?s)<request>.*</request>`).FindString(b.String())
+	if chunk != `<request>
+    <url>/query?t=xxx&amp;q=SHOW+x+BY+y+FROM+z</url>
+    <component/>
+    <action/>
+    <params>
+      <var key=q>SHOW x BY y FROM z</var>
+      <var key=t>xxx</var>
+    </params>
+  </request>` {
+		t.Fatal(chunk)
+	}
 }


### PR DESCRIPTION
Apologies for a somewhat larger change, I got progressively more greedy as I was eyeing the fancy Ruby errbits. The code change isn't actually that large, I mostly just extracted the common parameter compilation bit from `Error()` and `Notify()` into its own function `params()`, so that I can write a test for it. Bulk of the change is in the template, which unfortunately doesn't provide much room for making it more readable without adversely affecting its output. I'd be happy to convert it to ego style template if desired.

I added `PrettyParams` config variable, to allow including query/form parameters on the Environment tab which is more readable. I also tweaked the URL value a bit, because when using nested http muxes (as we do in reportifydb) they muck with the URL value.

One thing that bothers me still is the unused WHERE field that is so prominent (included even in the email notifications), but I didn't come up with something universally useful to put in there (Rails puts the Component#action there). Any suggestions welcome.

I tested this with a local custom reportifydb build. [sample errbit](https://exceptions.shopify.com/apps/54abfdafb74f33389b0002d7/errs/54ad7dd4b74f3338c3001bb2).

@tobi, would you have a minute to look this over?

@snormore, @burke: If you guys have any suggestions comments, please let me know.

PS: I'd like to follow this up with a PR with some backtrace fixes, hopefully also adding the line hyperlinking to github the same way the Ruby airbrake does. 